### PR TITLE
[action] Deploy the website on push to the `main` branch

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,17 @@
+name: Deploy Website
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@4
+
+      - name: Trigger Netlify build
+        run: |
+          curl -X POST -d {} ${secrets.WEBSITE_BUILD_HOOK} # TODO: Replace with the organization's build hook secret


### PR DESCRIPTION
This repo is a submodule of the website repo, so we need to deploy it on every change to this repo.

Let's consider this action as an experiment. In the event of success, we should add the corresponding secret to the organization itself and copy and paste this workflow to every project repository. Probably, create a project template repo with this workflow already in place? Is it possible?

Org secrets: https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets#creating-secrets-for-an-organization
